### PR TITLE
docs(opnsense,admin-ws): add OPNsense overview/build and Admin-WS baseline

### DIFF
--- a/VMs/bridge-node/README.md
+++ b/VMs/bridge-node/README.md
@@ -1,0 +1,71 @@
+# 🛰️ Bridge Node – Internal Routing & Utility VM
+
+> Part of the `home-lab` virtual network  
+> Role: lightweight Linux node bridging networks and providing essential utility functions.
+
+---
+
+## 📌 Purpose
+
+- Bridges internal network segments (LAN, DMZ, WRK)
+- Runs simple routing, firewalling, and test scripts
+- Ideal for scripting, traffic simulation, and diagnostics
+
+---
+
+## 🛠️ Base Configuration
+
+| Setting         | Value                          |
+|----------------|----------------------------------|
+| OS             | Arch Linux (minimal install)    |
+| Hostname       | `bridge-node`                   |
+| Interfaces     | `enp0s3` (mgmt), `enp0s8` (LAN), `enp0s9` (DMZ) |
+| Shell          | `zsh` with plugins              |
+| Services       | `openssh`, `iptables`, `systemd-networkd` |
+| User Accounts  | `john` (admin), `bridge` (limited) |
+
+---
+
+## 🧱 Network Role
+
+- NAT, packet inspection, routing
+- Interface mapping controlled by `systemd-networkd`
+- Optionally acts as:
+  - testbed
+  - access point
+  - DNS cache or NTP proxy
+
+---
+
+## 🔐 Credentials
+
+Stored securely in `config/bridge-node.creds` (not tracked by git)
+
+---
+
+## 📁 Notable Paths
+
+| Path                           | Description                  |
+|--------------------------------|------------------------------|
+| `/etc/systemd/network/`       | Static IP configs            |
+| `/etc/iptables/rules.v4`      | Firewall rules               |
+| `/opt/scripts/`               | Custom utility scripts       |
+| `/home/bridge/`               | Automation user shell config |
+
+---
+
+## 🧪 TODO
+
+- [ ] Add DNS cache or proxy
+- [ ] Install `fail2ban`
+- [ ] Add `vnstat` or `bmon` for bandwidth monitoring
+- [ ] Optionally bridge into host-only LAN for VM-to-real-network testing
+
+---
+
+## 📝 Notes
+
+- No GUI or unused services installed
+- SSH access configured
+- Will likely expand to include diagnostics and health checks
+

--- a/docs/network/opensense-build.md
+++ b/docs/network/opensense-build.md
@@ -1,0 +1,185 @@
+# OPNsense – Build & Configuration Guide
+
+> Hands‑on steps to install and configure OPNsense for the Home IT Lab.  
+> Pair with `opnsense-overview.md` for topology and policy.
+
+---
+
+## 0) Prep
+- **Download:** OPNsense AMD64 (VGA) ISO from official site; verify SHA256.
+- **Create media:** `dd`/Rufus/Ventoy.
+- **Plan addressing:** See overview for LAN/MGMT/VLANs.
+- **Have ready:** switch port map, ISP modem/ONT info.
+
+> **FIXME:** Record ISO version and SHA: `OPNsense x.y.z – sha256: <...>`
+
+---
+
+## 1) Install
+1. Boot installer → login `installer` (password `opnsense`) → launch guided install.
+2. **Filesystem:** ZFS (single‑disk) or UFS (simple).
+3. Create admin user `opn_admin`; disable root SSH.
+4. Set hostname `opnsense`, timezone, NTP pool.
+5. Reboot, remove install media.
+
+---
+
+## 2) Interface Assignment
+From console menu: **Assign interfaces**.
+- **WAN** → `ix0` (DHCP)  
+- **LAN** → `ix1` (static `192.168.10.1/24`)  
+- **MGMT** → `ix2` (static `192.168.99.1/24`)
+
+> **FIXME:** Replace `ix0/ix1/ix2` with real NICs.
+
+Confirm LAN access: connect laptop → `https://192.168.10.1` (self‑signed cert).
+
+---
+
+## 3) Base Hardening
+- **System ▸ Settings ▸ Administration**
+  - Protocol: HTTPS only (modern TLS)
+  - **SSH:** disabled by default; if enabled → MGMT net only, key‑auth only
+  - Idle timeout: 10–15 min
+- **System ▸ Trust ▸ Authorities**
+  - Import internal CA; issue firewall cert; set as GUI cert.
+- **System ▸ Firmware**
+  - Update to latest stable; reboot if required.
+
+---
+
+## 4) VLANs & Interface Setup
+- **Interfaces ▸ Other Types ▸ VLAN**
+  - Add trunk VLANs on the LAN uplink (e.g., `ix1`):
+    - VLAN **20** (Servers), **30** (Clients), **40** (CTF)
+- **Interfaces ▸ Assignments**
+  - Add OPT interfaces for each VLAN, then enable:
+    - `VLAN20` → `192.168.20.1/24`
+    - `VLAN30` → `192.168.30.1/24`
+    - `VLAN40` → `192.168.40.1/24`
+
+> **FIXME:** Confirm actual VLAN tags and trunk port on the switch.
+
+---
+
+## 5) DHCPv4
+- **Services ▸ DHCPv4** (per interface)
+  - **LAN:** pool `192.168.10.100–192.168.10.200`
+  - **MGMT:** **reservations only** (or tiny pool)
+  - **VLAN20:** narrow pool (servers mostly static/reserved)
+  - **VLAN30/40:** pools sized to expected clients
+  - Register DHCP leases in DNS (for Unbound)
+
+Add **static mappings** for infra nodes (MAC/IP/hostname notes in repo).
+
+---
+
+## 6) DNS Resolver (Unbound)
+- **Services ▸ Unbound DNS**
+  - Enable; DNSSEC on
+  - Register DHCP leases; static host overrides for core services
+  - (Optional) **Conditional forwarding** for any lab AD domain
+
+> Consider blocking outbound 53/853/DoH from clients to the Internet; force internal resolver.
+
+---
+
+## 7) Outbound NAT
+- **Firewall ▸ NAT ▸ Outbound**
+  - Mode: **Hybrid** (start from automatic, add explicit rules as needed)
+  - Ensure RFC1918 nets egress via WAN; add per‑VLAN overrides if using multiple WANs.
+
+---
+
+## 8) Firewall Policy (examples)
+**WAN**
+- Default deny inbound; allow established/related.
+
+**LAN/VLANs**
+- Default allow egress 80/443 via internal DNS only; deny inter‑VLAN by default.
+- Create **aliases** (FQDN/IP lists) for destinations; reference in rules.
+
+**MGMT**
+- Allow to infra mgmt ports (22/443/853) and resolver only.
+
+Example: allow `VLAN30` → GitHub (443) only:
+```
+
+Src: VLAN30 net
+Dst: Alias: GITHUB\_FQDNS
+Port: 443/TCP
+Action: Pass
+Description: Dev clients → GitHub
+
+```
+
+Log first, then tune.
+
+---
+
+## 9) VPN (WireGuard)
+- **VPN ▸ WireGuard**
+  - Add **Local**: UDP 51820 on WAN; Address: `10.99.0.1/24`
+  - Peers: Admin‑WS, phone (assign `10.99.0.2/32`, `10.99.0.3/32`)
+- **Firewall rules**
+  - WAN: allow UDP 51820
+  - WG interface: allow to **MGMT** subnet
+- **Routing**
+  - Add allowed‑IPs to include `192.168.99.0/24` (MGMT)
+
+> **FIXME:** Store private keys in your password vault, not the repo.
+
+---
+
+## 10) IDS/IPS (Suricata)
+- **Services ▸ Intrusion Detection**
+  - Interfaces: WAN (optionally LAN/VLANs later)
+  - Enable **IPS mode**
+  - Rule sets: **ET Open**, **abuse.ch**; auto‑update daily
+  - Suppress noisy FPs; maintain **suppress list** (no secrets) in repo as text
+
+---
+
+## 11) Port‑Forwards (if any)
+Document each forward with **justification** and **review date**:
+```
+
+Service: HTTPS to reverse proxy
+Src: WAN:443 → Dst: 192.168.20.10:443 (VLAN20)
+Why: External docs demo
+Risk: Exposed surface; WAF/Fail2Ban in front
+Review by: 2025‑10‑01
+
+```
+
+---
+
+## 12) Backups & Config History
+- **System ▸ Configuration ▸ Backups**
+  - Enable remote/automatic backups (Nextcloud/WebDAV/S3)
+  - **Encrypt** with strong passphrase (store in vault)
+- Export manual backup after major changes; label with date & PR #.
+
+---
+
+## 13) Monitoring & Health
+- **System ▸ Health** (CPU/mem/net)
+- **Firewall ▸ Logs ▸ Live View**
+- **Services ▸ Unbound/Suricata ▸ Logs**
+- (Optional) Netflow/Insight for traffic analysis.
+
+---
+
+## 14) Post‑Build Smoke Tests
+- Internet reachability from each VLAN (ICMP + HTTP)
+- DNS works via firewall resolver; external DNS blocked
+- Inter‑VLAN isolation holds
+- VPN connects; routes to MGMT only
+- IDS/IPS catching basic test signatures
+
+---
+
+## 15) Change Log
+- 2025‑08‑15 – Initial baseline build – PR #TBD
+- **Future:** record policy/rule changes here with rationale.
+

--- a/docs/network/opnsense-build.md
+++ b/docs/network/opnsense-build.md
@@ -1,0 +1,2 @@
+# OPNsense – Build & Configuration Guide
+<!-- FIXME: Install steps, VLANs, rules, VPN, IDS/IPS, backups. Added in Step 3. -->

--- a/docs/network/opnsense-overview.md
+++ b/docs/network/opnsense-overview.md
@@ -1,0 +1,2 @@
+# OPNsense – Overview & Runbook
+<!-- FIXME: Fill in topology, access points, policies. Added in Step 2. -->

--- a/docs/network/opnsense-overview.md
+++ b/docs/network/opnsense-overview.md
@@ -1,2 +1,61 @@
 # OPNsense – Overview & Runbook
-<!-- FIXME: Fill in topology, access points, policies. Added in Step 2. -->
+
+> High‑level reference for our edge firewall/router. Pair with `opnsense-build.md` for step‑by‑step configuration.
+
+## 📦 Role
+- Perimeter firewall, router, DHCP/DNS, VPN, IDS/IPS, and traffic shaping for the Home IT Lab.
+
+## 🗺️ Topology
+- **WAN**: DHCP from ISP (bridge mode if supported)
+- **LAN**: 192.168.10.0/24 (gateway 192.168.10.1)
+- **MGMT**: 192.168.99.0/24 (gateway 192.168.99.1)  ← Admin‑WS lives here
+- **LAB VLANs (planned)**
+  - VLAN 20 – Servers (192.168.20.0/24)
+  - VLAN 30 – Clients (192.168.30.0/24)
+  - VLAN 40 – Attacker/CTF (192.168.40.0/24)
+
+> **FIXME:** Replace interface names (e.g., `ix0/ix1/ix2`), actual VLAN tags, and switch ports.
+
+## 🔐 Access
+- Web UI: `https://opnsense.mgmt.local` (self‑signed or internal CA)
+- SSH: disabled by default (enable only during maintenance)
+- Admin user: `opn_admin` (key‑auth only; no password auth)
+
+> **Secrets live in vault/password manager; never in repo.**
+
+## 🧩 Core Services
+- **DHCPv4**: LAN + VLANs; reservations for infra nodes
+- **DNS Resolver (Unbound)**: host overrides + split‑horizon
+- **NAT**: automatic outbound for RFC1918; explicit port‑forwards documented in build guide
+- **VPN**: WireGuard for remote Admin‑WS access
+- **IDS/IPS**: Suricata in IPS mode on WAN (ET Open + abuse.ch; tuned)
+
+## ✅ Policy (Golden Rules)
+1. Default‑deny inbound; allow egress by policy.
+2. Inter‑VLAN is deny by default; allow via tight rules (FQDN/ports).
+3. Admin‑WS can reach infra (SSH/HTTPS) but not client VLANs except break‑glass.
+4. Management only over TLS/SSH key‑auth.
+
+## 🔄 Change Control
+- Track config backups (`System ▸ Configuration ▸ Backups`) and store encrypted off‑box.
+- Document meaningful changes in PRs referencing this doc.
+
+## 🧯 Break‑Glass
+- Console (VGA/serial) available.
+- If needed: factory reset → restore last known‑good config from encrypted backup.
+
+## 🧪 Post‑Change Smoke Tests
+- WAN up? (`Interfaces ▸ Overview`)
+- DHCP leases issuing on LAN/VLANs?
+- DNS resolution from Admin‑WS (`dig a example.com @192.168.10.1`)
+- VLAN separation enforced?
+- VPN up and routes to MGMT?
+
+## 🛠️ Troubleshooting Pointers
+- DNS: `Services ▸ Unbound DNS ▸ Log File`
+- VPN: `VPN ▸ WireGuard ▸ Status`
+- Firewall: `Firewall ▸ Log Files ▸ Live View` (filter src/dst)
+- Packet capture: `Interfaces ▸ Diagnostics ▸ Packet Capture`
+
+## 📎 References
+- OPNsense docs (stable), Suricata tuning notes (local), WireGuard keys (vault item).

--- a/docs/workstations/admin-ws-build.md
+++ b/docs/workstations/admin-ws-build.md
@@ -1,0 +1,2 @@
+# Admin-WS – Build & Baseline
+<!-- FIXME: OS baseline, tools, secrets policy, firewall. Added in Step 4. -->

--- a/docs/workstations/admin-ws-build.md
+++ b/docs/workstations/admin-ws-build.md
@@ -1,2 +1,245 @@
 # Admin-WS – Build & Baseline
-<!-- FIXME: OS baseline, tools, secrets policy, firewall. Added in Step 4. -->
+
+> Opinionated, repeatable setup for the lab’s admin workstation.  
+> Priorities: security, reliability, terminal-first ops, and **no secrets in git**.
+
+---
+
+## 🧾 Host Summary
+- OS: Parrot OS (rolling)  
+- Hostname: `admin-ws`  
+- Network: **MGMT** VLAN `192.168.99.0/24` (static or DHCP reservation)  
+- Accounts: primary user `john` (sudo); root login disabled over SSH  
+- Remote access: WireGuard to MGMT only
+
+> **FIXME:** Record the actual MGMT IP/MAC and DHCP reservation ID.
+
+---
+
+## 1) Fresh Install & System Basics
+- Install Parrot OS → full-disk encryption recommended.
+- Set timezone, NTP, and hostname.
+- Enable auto-security updates.
+
+```bash
+sudo apt update && sudo apt -y full-upgrade
+sudo apt -y install \
+  git vim neovim tmux zsh curl wget unzip jq htop tree \
+  openssh-client wireguard openvpn \
+  python3 python3-pip python3-venv \
+  ansible nmap netcat-traditional socat \
+  wireshark tcpdump traceroute whois \
+  feroxbuster gobuster wfuzz seclists \
+  keepassxc pass gnupg2 age \
+  virt-manager qemu-system-x86 remmina \
+  make build-essential ripgrep fd-find bat fzf
+````
+
+Optional desktop utilities: `gnome-disk-utility`, `flameshot`.
+
+---
+
+## 2) Shell, Editor, and Tmux Quality-of-Life
+
+```bash
+chsh -s /bin/zsh "$USER"
+
+# Vim/Neovim minimal defaults (idempotent)
+mkdir -p ~/.config/nvim
+cat > ~/.vimrc <<'VIM'
+set number relativenumber cursorline
+set tabstop=2 shiftwidth=2 expandtab
+set ignorecase smartcase
+set clipboard=unnamedplus
+syntax on
+VIM
+ln -sf ~/.vimrc ~/.config/nvim/init.vim
+
+# Tmux sane defaults
+cat > ~/.tmux.conf <<'TMUX'
+set -g mouse on
+set -g history-limit 20000
+setw -g mode-keys vi
+TMUX
+```
+
+---
+
+## 3) SSH & GPG/Pass (no passwords in plain text)
+
+**SSH**
+
+```bash
+ssh-keygen -t ed25519 -a 100 -f ~/.ssh/id_ed25519 -C "admin-ws"
+printf "Host *\n  AddKeysToAgent yes\n  IdentityFile ~/.ssh/id_ed25519\n" >> ~/.ssh/config
+chmod 700 ~/.ssh && chmod 600 ~/.ssh/*
+```
+
+**GPG + pass**
+
+```bash
+# Create a primary key (adjust name/email)
+gpg --quick-generate-key "John Admin <admin@example.local>" default default never
+KEYID=$(gpg --list-secret-keys --keyid-format LONG | awk '/sec/{print $2}' | sed -n '1s|.*/||p')
+pass init "$KEYID"
+```
+
+> Store service passwords, API tokens, and **WireGuard private keys** in KeePassXC or `pass`.
+> Back up the KeePass DB and GPG private key offline.
+
+---
+
+## 4) Local Host Firewall (UFW)
+
+```bash
+sudo apt -y install ufw
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+# Allow SSH only from MGMT
+sudo ufw allow from 192.168.99.0/24 to any port 22 proto tcp
+sudo ufw enable
+sudo ufw status verbose
+```
+
+---
+
+## 5) Network & Name Resolution
+
+* Prefer **DHCP reservation** on MGMT; otherwise static:
+
+```bash
+# Example Netplan (if using netplan). Replace IFACE/IP details.
+# /etc/netplan/01-mgmt.yaml
+network:
+  version: 2
+  ethernets:
+    IFACE0:
+      addresses: [192.168.99.10/24]
+      routes: [{ to: default, via: 192.168.99.1 }]
+      nameservers: { addresses: [192.168.99.1] }
+```
+
+Apply with `sudo netplan apply`.
+
+Optional `/etc/hosts` short names for infra (jump host, opnsense, etc.).
+
+---
+
+## 6) WireGuard (Remote Admin)
+
+```bash
+umask 077
+wg genkey | tee ~/wg-admin.key | wg pubkey > ~/wg-admin.pub
+# Store ~/wg-admin.key in pass/KeePassXC (NOT in git)
+
+# Client config (example): /etc/wireguard/wg-mgmt.conf
+[Interface]
+PrivateKey = <contents of ~/wg-admin.key>
+Address = 10.99.0.2/32
+DNS = 192.168.99.1
+
+[Peer]
+PublicKey = <OPNsense-WG-PublicKey>
+Endpoint = <WAN_IP>:51820
+AllowedIPs = 192.168.99.0/24
+PersistentKeepalive = 25
+
+sudo wg-quick up wg-mgmt
+sudo systemctl enable wg-quick@wg-mgmt
+```
+
+> **FIXME:** fill actual keys and OPNsense public key (keep private in vault).
+
+---
+
+## 7) Tooling Profiles (CTF + Admin)
+
+* Recon: `nmap`, `feroxbuster`, `gobuster`, `wfuzz`, `seclists`
+* Net/packets: `tcpdump`, `wireshark` (add user to `wireshark` group)
+* Infra: `ansible`, `virt-manager`, `remmina`
+* Developer QoL: `ripgrep`, `fd`, `bat`, `fzf`
+
+**Wireshark permissions**
+
+```bash
+sudo dpkg-reconfigure wireshark-common   # allow non-root captures
+sudo usermod -aG wireshark "$USER"
+newgrp wireshark
+```
+
+---
+
+## 8) Ansible (optional but recommended)
+
+Repo path: `~/home-lab/automation/ansible/`
+
+* `inventory.yml` (MGMT IPs)
+* `group_vars/` for non-secret vars
+* Roles:
+
+  * `roles/workstation_bootstrap` (install pkgs, dotfiles)
+  * `roles/opnsense_readonly` (API GETs only for config snapshots)
+
+> Keep secrets in Ansible Vault or `pass`; never commit raw credentials.
+
+---
+
+## 9) Git Hygiene on Admin-WS
+
+Global config tweaks:
+
+```bash
+git config --global pull.ff only
+git config --global init.defaultBranch main
+git config --global commit.gpgsign true   # if using signed commits
+git config --global user.signingkey "$KEYID"
+```
+
+Helpful aliases (optional):
+
+```ini
+# ~/.gitconfig snippet
+[alias]
+  st = status -sb
+  co = checkout
+  cb = checkout -b
+  fp = fetch --prune
+  lol = log --oneline --graph --decorate --all
+  amend = commit --amend --no-edit
+  wip = commit -m "chore: wip"
+  fixup = commit --fixup
+  squash = rebase -i --autosquash
+```
+
+---
+
+## 10) Backups & Key Escrow
+
+* KeePassXC DB exported to **encrypted** external storage (periodic).
+* GPG private key + revocation cert stored offline.
+* Timeshift/rsync snapshot to NAS on MGMT only.
+
+---
+
+## 11) Security Notes
+
+* Browser: separate profiles for admin vs. general browsing.
+* Disable USB autorun; keep full-disk encryption.
+* Review `~/.ssh/known_hosts` periodically.
+
+---
+
+## 12) Smoke Tests
+
+* Access OPNsense GUI from Admin-WS.
+* `ssh` to infra nodes on MGMT (as-needed).
+* Run an `nmap -sn 192.168.99.0/24` to validate reachability.
+* Bring up WireGuard and verify route to MGMT only.
+* Capture a quick `tcpdump -i <iface> host 192.168.99.1` (permissions OK).
+
+---
+
+## 13) Change Log
+
+* 2025-08-15 – Baseline created – PR #TBD
+  MD


### PR DESCRIPTION
### Summary
Adds initial network and workstation documentation for the Home IT Lab.

### Included
- **`docs/network/opnsense-overview.md`** – Topology, policies, core services, smoke tests.
- **`docs/network/opnsense-build.md`** – Installation, VLANs, DHCP/DNS, VPN, IDS/IPS, backups.
- **`docs/workstations/admin-ws-build.md`** – Baseline packages, SSH/GPG setup, UFW, WireGuard, tooling.

### Why
- Create a single source of truth for OPNsense and the primary admin workstation.
- Support reproducible builds, onboarding, and audit trails.
- Lay groundwork for automation (Ansible roles) and config change control.

### Notes
- **FIXME placeholders** remain for interface names, VLAN tags, IP reservations, and cryptographic keys.  
  Fill post-merge with environment-specific details.
- No secrets committed; `.gitignore` already protects sensitive paths.

### Review Checklist
- [ ] Scope is single-topic, <300 LOC per commit.
- [ ] No unrelated drive-by changes.
- [ ] All new docs render correctly in GitHub Markdown.
- [ ] Secrets remain out of repo.

---

Closes #<issue-number-if-any>
