### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,50 @@
-## What / Why
--
+## Summary
+<!-- Short, clear description of the change (1–3 sentences) -->
 
-## How to Test
--
+## What’s Included
+<!-- Bullet list of files, features, fixes, docs added/changed -->
 
-## Checklist
-- [ ] Small, focused changes
-- [ ] Docs updated
-- [ ] No secrets committed
-- [ ] CI green
+## Why This Change
+<!-- Explain the problem, motivation, or requirement this PR addresses -->
 
-Closes #
+## Scope & Impact
+- [ ] Single topic / < 300 LOC changed
+- [ ] No unrelated drive-by changes
+- [ ] No secrets or sensitive data committed
+- [ ] Backwards-compatible (no breaking changes)
+- [ ] Requires follow-up work (list below)
+
+## Review Checklist
+- [ ] Code/docs render correctly (Markdown formatting OK)
+- [ ] Conventional commit message(s) used
+- [ ] CI checks green
+- [ ] Tests/docs updated if behavior changed
+
+## Notes
+<!-- Any extra context, FIXME placeholders, or follow-up tasks -->
+
+## Related Issues / Links
+Closes #<issue-number> <!-- or "Refs #<issue-number>" -->
+
+---
+
+### Example Commit Messages
+```
+
+feat(api): add token refresh
+fix(net): correct NAT rule order
+docs(readme): add setup steps
+chore(ci): bump actions/checkout
+
+```
+```
+
+---
+
+**Branch & Commit Reminder**
+
+* Branch: `feature/<scope>-<desc>` · `fix/<issue>-<desc>` · `docs/<area>` · `chore/<task>`
+* Commit style: `type(scope): short description` (Conventional Commits)
+* Scope examples: `api`, `net`, `readme`, `opnsense`, `admin-ws`
+
+


### PR DESCRIPTION
### Summary
Adds a standardized PR template to `.github/` to align with our Git & GitHub Pro Workflow.

### Why
- Ensures every PR is small, single-topic, and follows Conventional Commits.
- Helps reviewers verify scope, security, and formatting.

### Included
- `.github/PULL_REQUEST_TEMPLATE.md` – review checklist, commit style guide, and example messages.

### Notes
- Future improvement: add `.github/ISSUE_TEMPLATE/` for bug and feature requests.
